### PR TITLE
Nerfing industrial city state

### DIFF
--- a/jsons/CityStateTypes.json
+++ b/jsons/CityStateTypes.json
@@ -17,17 +17,12 @@
 	
 	{
 		"name": "Industrial",
-		"friendBonusUniques":  [
-			"[+2 Production] [in all cities] <before the [Heroic age]>",
-			"[+4 Production] [in all cities] <starting from the [Heroic age]> <before the [Renaissance age]>",
-			"[+6 Production] [in all cities] <starting from the [Renaissance age]>",
-			"[+2 Production] [in capital] <starting from the [Industrial age]>"
-		],
-		"allyBonusUniques":  [
-			"[+4 Production] [in all cities] <before the [Heroic age]>",
-			"[+8 Production] [in all cities] <starting from the [Heroic age]> <before the [Renaissance age]>",
-			"[+12 Production] [in all cities] <starting from the [Renaissance age]>",
+		"friendBonusUniques": [
 			"[+2 Production] [in capital]"
+		],
+		"allyBonusUniques": [
+			"[+2 Production] [in capital]",
+			"[+1 Production] [in all cities]"
 		],
 		"color": [139,69,19]
 	},


### PR DESCRIPTION
I gave them comparable yields as the food CS, if you think it's too weak you could add a bit more production in capital or for passing ages, just not +2/+4/+8/+12 production per city, that's extremely OP. I also recommend splitting the Mercantile city states into separate happiness and gold type bonuses, as the gold can be used to keep purchasing influence from the CS so it doesn't decay.